### PR TITLE
Prevent creation of 0-stack emeralds in chest

### DIFF
--- a/src/main/java/net/uvnode/uvvillagers/UVVillagers.java
+++ b/src/main/java/net/uvnode/uvvillagers/UVVillagers.java
@@ -919,7 +919,7 @@ public final class UVVillagers extends JavaPlugin implements Listener {
                                 }
                             }
                         }
-                        if (_tributeMethod.equalsIgnoreCase("chest") && village.getValue().hasChest()) {
+                        if (_tributeMethod.equalsIgnoreCase("chest") && village.getValue().hasChest() && tributeAmount > 0) {
                             ItemStack items;
                             if (_emeraldTributeItem > 0 && Material.getMaterial(_emeraldTributeItem) != null) {
                                 items = new ItemStack(Material.getMaterial(_emeraldTributeItem), tributeAmount);


### PR DESCRIPTION
If Tribute amount is less than 1. Emeralds created in tribute chest improperly (players can try to pickup them put it leads to disappearing).
